### PR TITLE
Add solo raids bots server example

### DIFF
--- a/examples/solo-raids-bots/README.md
+++ b/examples/solo-raids-bots/README.md
@@ -1,0 +1,46 @@
+# Solo server with raids and bots
+
+This example spins up a private Rust server using the Oxide-enabled Docker image.
+It adds bot-controlled raids, monument patrols, and timed events to simulate a
+full server while you play alone.
+
+## Usage
+
+```shell
+git clone https://github.com/max-pfeiffer/rust-game-server-docker.git
+cd rust-game-server-docker/examples/solo-raids-bots
+docker compose up -d
+```
+
+Stop the server with:
+
+```shell
+docker compose down
+```
+
+## Plugins
+
+Download the required plugins and place the `.cs` files in
+`oxide/plugins/` (see [oxide/plugins/README.md](oxide/plugins/README.md)):
+
+- BotSpawn – roaming NPCs
+- TruePVE – prevent player-vs-player damage
+- BetterLoot – balanced loot tables
+- HeliControl – control patrol helicopter spawns
+- BradleyControl – control Bradley APC respawns
+- AirDropExtended – schedule airdrops
+- Raidable Bases – procedurally generated raid bases *(premium plugin)*
+
+## Configuration
+
+Plugin configuration files are located in `oxide/config/` and can be adjusted
+as needed. The Rust server configuration resides in
+`server/solo_server/cfg/server.cfg`.
+
+## Connect
+
+From the Rust client console, connect to the server:
+
+```shell
+client.connect <your-ip>:28015
+```

--- a/examples/solo-raids-bots/compose.yaml
+++ b/examples/solo-raids-bots/compose.yaml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+services:
+  rust:
+    image: pfeiffermax/rust-game-server:latest-oxide
+    container_name: rust-solo-raids-bots
+    restart: unless-stopped
+    ports:
+      - "28015:28015/udp"   # game
+      - "28016:28016"       # RCON
+    environment:
+      RUST_SERVER_STARTUP_ARGUMENTS: >-
+        -batchmode -nographics +server.port 28015 +server.level "Procedural Map"
+        +server.seed 123456 +server.worldsize 3500
+        +server.identity "solo_server" +server.hostname "Rust Solo Raids & Bots"
+        +server.description "Servidor privado con raids, bots y eventos"
+        +rcon.port 28016 +rcon.password "CambialaYA"
+        +server.secure 1
+      RUST_SERVER_MAXPLAYERS: "1"
+      RUST_SERVER_TAGS: "pve,solo,oxide,events,raids"
+    volumes:
+      - ./server:/steamcmd/rust
+      - ./oxide/plugins:/steamcmd/rust/oxide/plugins
+      - ./oxide/config:/steamcmd/rust/oxide/config
+    stop_grace_period: 30s

--- a/examples/solo-raids-bots/oxide/config/AirDropExtended.json
+++ b/examples/solo-raids-bots/oxide/config/AirDropExtended.json
@@ -1,0 +1,3 @@
+{
+  "Airdrop": { "Enable": true, "TimerMinutes": 20, "PlaneSpeed": 1.0 }
+}

--- a/examples/solo-raids-bots/oxide/config/BetterLoot.json
+++ b/examples/solo-raids-bots/oxide/config/BetterLoot.json
@@ -1,0 +1,5 @@
+{
+  "Enable": true,
+  "IncludeWorkshopSkins": false,
+  "ItemListBlacklist": []
+}

--- a/examples/solo-raids-bots/oxide/config/BotSpawn.json
+++ b/examples/solo-raids-bots/oxide/config/BotSpawn.json
@@ -1,0 +1,9 @@
+{
+  "Global": { "Bots_Drop_Weapons": false, "Ignore_Animals": true },
+  "Roads": { "Enabled": true, "Murderer_Amounts": 0, "Scientist_Amounts": 3 },
+  "Monuments": {
+    "Launch Site": { "Enabled": true, "Bots": 8 },
+    "Airfield":     { "Enabled": true, "Bots": 6 },
+    "Train Yard":   { "Enabled": true, "Bots": 6 }
+  }
+}

--- a/examples/solo-raids-bots/oxide/config/BradleyControl.json
+++ b/examples/solo-raids-bots/oxide/config/BradleyControl.json
@@ -1,0 +1,3 @@
+{
+  "Bradley": { "Enable": true, "RespawnMinutes": 45 }
+}

--- a/examples/solo-raids-bots/oxide/config/HeliControl.json
+++ b/examples/solo-raids-bots/oxide/config/HeliControl.json
@@ -1,0 +1,3 @@
+{
+  "Helicopter": { "Enable": true, "SpawnIntervalMinutes": 90 }
+}

--- a/examples/solo-raids-bots/oxide/config/RaidableBases.json
+++ b/examples/solo-raids-bots/oxide/config/RaidableBases.json
@@ -1,0 +1,22 @@
+{
+  "Enabled": true,
+  "Use TruePVE": true,
+  "Difficulty Profiles": ["Easy","Medium","Hard"],
+  "Scheduled Events": {
+    "Enabled": true,
+    "Use Real Time": false,
+    "Min Time Between Spawns (minutes)": 25,
+    "Max Time Between Spawns (minutes)": 35,
+    "Maximum Concurrent Bases": 2
+  },
+  "NPCs": {
+    "Spawn Scientists": true,
+    "Min NPCs": 4,
+    "Max NPCs": 10
+  },
+  "Despawn": {
+    "Despawn Minutes After Completed": 15,
+    "Despawn Minutes If Uncontested": 60
+  },
+  "Chat Notifications": true
+}

--- a/examples/solo-raids-bots/oxide/config/TruePVE.json
+++ b/examples/solo-raids-bots/oxide/config/TruePVE.json
@@ -1,0 +1,14 @@
+{
+  "useZones": false,
+  "defaultAllowDamage": true,
+  "rules": [
+    { "name": "no-pvp", "description": "bloquea PvP", "priority": 1,
+      "flags": ["HumanHuman", "HurtPlayer"],
+      "allow": false
+    },
+    { "name": "pve-ok", "description": "NPCs permitidos", "priority": 2,
+      "flags": ["HumanNPC"],
+      "allow": true
+    }
+  ]
+}

--- a/examples/solo-raids-bots/oxide/plugins/README.md
+++ b/examples/solo-raids-bots/oxide/plugins/README.md
@@ -1,0 +1,12 @@
+# Oxide plugins
+
+Download the following plugins from [uMod](https://umod.org) and place the `.cs` files in this directory:
+
+- [BotSpawn](https://umod.org/plugins/botspawn)
+- [TruePVE](https://umod.org/plugins/truepve)
+- [BetterLoot](https://umod.org/plugins/betterloot)
+- [HeliControl](https://umod.org/plugins/helicontrol)
+- [BradleyControl](https://umod.org/plugins/bradleycontrol)
+- [AirDropExtended](https://umod.org/plugins/airdropextended)
+
+The Raidable Bases plugin is a premium plugin and cannot be redistributed. Purchase or obtain it from [ChaosCode](https://chaoscode.io/resources/raidable-bases.1225/) and place `RaidableBases.cs` in this folder as well.

--- a/examples/solo-raids-bots/server/solo_server/cfg/server.cfg
+++ b/examples/solo-raids-bots/server/solo_server/cfg/server.cfg
@@ -1,0 +1,12 @@
+server.maxplayers 1
+# Use TruePVE to manage damage rules; keep server.pve disabled
+server.pve false
+server.saveinterval 300
+decay.scale 0.5
+heli.lifetimeminutes 15
+spawn.max_rate 1
+spawn.max_density 1
+spawn.min_density 1
+server.ip 0.0.0.0
+server.secure 1
+server.tags "solo,pve,oxide,events,raids"


### PR DESCRIPTION
## Summary
- add `solo-raids-bots` example with Docker Compose
- include server and plugin configuration for raids, bots, and events

## Testing
- `pre-commit run --files examples/solo-raids-bots/compose.yaml examples/solo-raids-bots/README.md examples/solo-raids-bots/server/solo_server/cfg/server.cfg examples/solo-raids-bots/oxide/plugins/README.md examples/solo-raids-bots/oxide/config/AirDropExtended.json examples/solo-raids-bots/oxide/config/BradleyControl.json examples/solo-raids-bots/oxide/config/HeliControl.json examples/solo-raids-bots/oxide/config/BetterLoot.json examples/solo-raids-bots/oxide/config/BotSpawn.json examples/solo-raids-bots/oxide/config/TruePVE.json examples/solo-raids-bots/oxide/config/RaidableBases.json` (failed: `pre-commit` not installed and `pip` install blocked)
- `pytest` (failed: ModuleNotFoundError: python_on_whales)
- `pip install pre-commit` (failed: proxy 403)
- `pip install python-on-whales` (failed: proxy 403)


------
https://chatgpt.com/codex/tasks/task_e_68955b8403a08333bbce893776b1c7cb